### PR TITLE
Support for Non-encoded object IDs in the GraphQL Storefront API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ npm i shopify-gid --save
 ```javascript
 import { encode, decode } from 'shopify-gid'
 ```
-## decode(base64hash)
+## decode(base64hash) OR decode(globalID)
 ```javascript
 decode('Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzEyMzQ1...')
+        //OR
+decode('gid://shopify/Product/12345')
   // => { type: 'Product', id: '12345', params: { accessToken: 'abcde123' }, raw: 'Z2lkOi8...' }
 ```
 ## encode(type, id[, params])

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 export function decode (str) {
   const raw = (typeof window === 'undefined' ? (
-    Buffer.from(str, 'base64').toString('utf-8')
+      str.lastIndexOf("gid://shopify/")===0?str:Buffer.from(str, 'base64').toString('utf-8')
   ) : (
-    atob(str) // eslint-disable-line no-undef
+      str.lastIndexOf("gid://shopify/")===0?str:atob(str) // eslint-disable-line no-undef
   )).split('shopify/')[1]
 
   const [ type, id ] = raw.split('/')


### PR DESCRIPTION
In API version 2022-04, using Base64-encoded object IDs as arguments to fields and mutations was deprecated. Support for this behavior is removed in API version 2023-01.
[<< Check More Detail Here >>
](https://shopify.dev/docs/api/release-notes/2022-04#non-encoded-object-ids-in-the-graphql-storefront-api
)
